### PR TITLE
Optimized TextState Rendering

### DIFF
--- a/src/main/java/org/liquidengine/legui/system/renderer/nvg/util/NvgText.java
+++ b/src/main/java/org/liquidengine/legui/system/renderer/nvg/util/NvgText.java
@@ -1,23 +1,5 @@
 package org.liquidengine.legui.system.renderer.nvg.util;
 
-import static org.lwjgl.nanovg.NanoVG.NVG_ALIGN_BASELINE;
-import static org.lwjgl.nanovg.NanoVG.NVG_ALIGN_BOTTOM;
-import static org.lwjgl.nanovg.NanoVG.NVG_ALIGN_CENTER;
-import static org.lwjgl.nanovg.NanoVG.NVG_ALIGN_LEFT;
-import static org.lwjgl.nanovg.NanoVG.NVG_ALIGN_MIDDLE;
-import static org.lwjgl.nanovg.NanoVG.NVG_ALIGN_RIGHT;
-import static org.lwjgl.nanovg.NanoVG.NVG_ALIGN_TOP;
-import static org.lwjgl.nanovg.NanoVG.nnvgText;
-import static org.lwjgl.nanovg.NanoVG.nnvgTextBreakLines;
-import static org.lwjgl.nanovg.NanoVG.nvgBeginPath;
-import static org.lwjgl.nanovg.NanoVG.nvgFillColor;
-import static org.lwjgl.nanovg.NanoVG.nvgFontFace;
-import static org.lwjgl.nanovg.NanoVG.nvgFontSize;
-import static org.lwjgl.nanovg.NanoVG.nvgTextAlign;
-import static org.lwjgl.system.MemoryUtil.memAddress;
-import static org.lwjgl.system.MemoryUtil.memUTF8;
-
-import java.nio.ByteBuffer;
 import org.joml.Vector2f;
 import org.joml.Vector2fc;
 import org.joml.Vector4f;
@@ -29,6 +11,12 @@ import org.lwjgl.nanovg.NVGColor;
 import org.lwjgl.nanovg.NVGTextRow;
 import org.lwjgl.system.MemoryUtil;
 
+import java.nio.ByteBuffer;
+
+import static org.lwjgl.nanovg.NanoVG.*;
+import static org.lwjgl.system.MemoryUtil.memAddress;
+import static org.lwjgl.system.MemoryUtil.memUTF8;
+
 /**
  * Created by ShchAlexander on 19.09.2017.
  */
@@ -38,6 +26,7 @@ public class NvgText {
     }
 
     public static void drawTextLineToRect(long nvg, TextState text, Vector2fc pos, Vector2fc size, boolean hideOverflow) {
+        if(text.length() == 0) return;
         Vector4f p = text.getPadding();
         Vector4f rect = new Vector4f(pos.x(), pos.y(), size.x(), size.y()).add(p.x, p.y, -p.x - p.z, -p.y - p.w);
         drawTextLineToRect(nvg, text, rect, hideOverflow);


### PR DESCRIPTION
The issues was that buttons with only icon and no text, were trying to render it, this avoids rendering empty strings.

Also for some reason the constructor `String(char[] value, boolean shared)` takes a long time to create a String, probably JVM has some sort of internal optimization mechanism.

Fix #54