### PR TITLE
Use simple point in axis-aligned rectangle test

### DIFF
--- a/src/main/java/org/liquidengine/legui/intersection/RectangleIntersector.java
+++ b/src/main/java/org/liquidengine/legui/intersection/RectangleIntersector.java
@@ -3,7 +3,6 @@ package org.liquidengine.legui.intersection;
 import java.util.HashMap;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import org.joml.PolygonsIntersection;
 import org.joml.Vector2f;
 import org.liquidengine.legui.component.Component;
 
@@ -19,16 +18,7 @@ public class RectangleIntersector extends Intersector {
         float y = pos.y;
         float w = component.getSize().x;
         float h = component.getSize().y;
-        float verticies[] = {
-            x, y,
-            x + w, y,
-            x + w, y + h,
-            x, y + h
-        };
-        int start[] = {0};
-        int count = 4;
-        PolygonsIntersection intersector = new PolygonsIntersection(verticies, start, count);
-        return intersector.testPoint(point.x, point.y);
+        return point.x >= x && point.x <= x + w && point.y >= y && point.y <= y + h;
     }
 
     /**


### PR DESCRIPTION
Using JOML's PolygonsIntersection is _really_ a massive overkill and a big performance bottleneck given how many times this method is being called. Also the PolygonsIntersection's constructor constructs a whole tree data structure internally and that produces a lot of memory allocations. You should see this when you use a memory profile.

Since you are dealing with a very very simple axis-aligned rectangle, there is a _muuuch_ faster and allocation-free way to compute whether a point is inside of that rectangle.